### PR TITLE
Guard defaultACL map access with a RWMutex

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,11 @@ To install, run:
    ```
 
 To run the tests, you'll need to connect to a Postgres database:
+```
+export POSTGRES_DSN="user=postgres dbname=nogo host=localhost port=5432 sslmode=disable"
 
-POSTGRES_DSN="name= dbname= host= port= sslmode=" go test
+go test
+```
 
 Functionality
 =============


### PR DESCRIPTION
Guard the ACE map in the defaultACL implementation with a RWMutex.
There is a data race condition, when performing concurrent reads and writes with the current implementation.

Tested using:

```
go test -covermode=atomic -cpu=1,2,4 -race ./...
```
